### PR TITLE
New whereIf() Base Query Builder method added

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1775,11 +1775,11 @@ class Builder
      * User::whereIf(!$check,'name', fn($q)=>$q->where('name','laravel', fn($q)=>$q->where('name','lumen');
      *      # select * from users name = 'lumen' and deleted_at is null
      *
-     * @param  bool  $condition
+     * @param  mixed  $condition
      * @param  mixed  $arguments
      * @return $this
      */
-    public function whereIf(bool $condition, ...$arguments)
+    public function whereIf($condition, ...$arguments)
     {
         if ($condition) {
             return $arguments[0] instanceof \Closure ? $arguments[0]($this, $condition) : $this->where(...$arguments);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1761,19 +1761,6 @@ class Builder
 
     /**
      * Apply the where condition if the given $condition is truthy.
-     * If the rest of the $arguments are closures then whereIf() exactly act like when() method.
-     *
-     * @example assume $check = true then
-     * User::whereIf($check,'name','like','%laravel%');
-     *      # select * from users name like '%laravel%' and deleted_at is null
-     * User::whereIf($check,'name','laravel');
-     *      # select * from users name = 'laravel' and deleted_at is null
-     * User::whereIf(!$check,'name','like','%laravel%');
-     *      # select * from users  and deleted_at is null
-     * User::whereIf($check,'name', fn($q)=>$q->where('name','laravel');
-     *      # select * from users name = 'laravel' and deleted_at is null
-     * User::whereIf(!$check,'name', fn($q)=>$q->where('name','laravel', fn($q)=>$q->where('name','lumen');
-     *      # select * from users name = 'lumen' and deleted_at is null
      *
      * @param  mixed  $condition
      * @param  mixed  $arguments

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1770,7 +1770,7 @@ class Builder
     {
         if ($condition) {
             return $arguments[0] instanceof \Closure ? $arguments[0]($this, $condition) : $this->where(...$arguments);
-        } elseif ($arguments[1] instanceof \Closure) {
+        } elseif (isset($arguments[1]) && $arguments[1] instanceof \Closure) {
             return $arguments[1]($this, $condition);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1760,6 +1760,37 @@ class Builder
     }
 
     /**
+     * Apply the where condition if the given $condition is truthy.
+     * If the rest of the $arguments are closures then whereIf() exactly act like when() method.
+     *
+     * @example assume $check = true then
+     * User::whereIf($check,'name','like','%laravel%');
+     *      # select * from users name like '%laravel%' and deleted_at is null
+     * User::whereIf($check,'name','laravel');
+     *      # select * from users name = 'laravel' and deleted_at is null
+     * User::whereIf(!$check,'name','like','%laravel%');
+     *      # select * from users  and deleted_at is null
+     * User::whereIf($check,'name', fn($q)=>$q->where('name','laravel');
+     *      # select * from users name = 'laravel' and deleted_at is null
+     * User::whereIf(!$check,'name', fn($q)=>$q->where('name','laravel', fn($q)=>$q->where('name','lumen');
+     *      # select * from users name = 'lumen' and deleted_at is null
+     *
+     * @param  bool  $condition
+     * @param  mixed  $arguments
+     * @return $this
+     */
+    public function whereIf(bool $condition, ...$arguments)
+    {
+        if ($condition) {
+            return $arguments[0] instanceof \Closure ? $arguments[0]($this, $condition) : $this->where(...$arguments);
+        } elseif ($arguments[1] instanceof \Closure) {
+            return $arguments[1]($this, $condition);
+        }
+
+        return $this;
+    }
+
+    /**
      * Handles dynamic "where" clauses to the query.
      *
      * @param  string  $method


### PR DESCRIPTION
### Applies the where condition if the given $condition is truthy.
    
 **Example:**
      assume $check = true then,

`User::whereIf($check,'name','like','%laravel%');`
> SELECT * FROM users name LIKE '%laravel%' and deleted_at IS NULL

`User::whereIf($check,'name','laravel');`
> SELECT * FROM users name = 'laravel' and deleted_at IS NULL

`User::whereIf(!$check,'name','like','%laravel%');`
> SELECT * FROM users  and deleted_at IS NULL

`User::whereIf($check,'name', fn($q)=>$q->where('name','laravel');`
> SELECT * FROM users name = 'laravel' and deleted_at IS NULL

`User::whereIf(!$check,'name', fn($q)=>$q->where('name','laravel', fn($q)=>$q->where('name','lumen');`
> SELECT * FROM users name = 'lumen' and deleted_at IS NULL

**Note:**
If the rest of the $arguments are closures then whereIf() exactly act like when() method.